### PR TITLE
fix: Remove nonexistent status check

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -24,7 +24,6 @@ branchProtectionRules:
   requiresStrictStatusChecks: false
   requiredStatusCheckContexts:
     - 'cla/google'
-    - 'test'
     - 'snippet-bot check'
     - 'header-check'
   requiredApprovingReviewCount: 1
@@ -34,8 +33,7 @@ branchProtectionRules:
   requiresStrictStatusChecks: false
   requiredStatusCheckContexts:
     - 'cla/google'
-    - 'test'
-    - 'snippet-bot-check'
+    - 'snippet-bot check'
     - 'header-check'
   requiredApprovingReviewCount: 1
   requiresCodeOwnerReviews: true


### PR DESCRIPTION
#4 added a new status check that refers to a nonexistent "test" workflow and is currently blocking all new PRs. The request for adding tests should have been created as a feature request on the Issues page instead.