### PR TITLE
refactor: Switch to using Metal renderer

### DIFF
--- a/objectivec_samples/Consumer/App/GRSCAppDelegate.m
+++ b/objectivec_samples/Consumer/App/GRSCAppDelegate.m
@@ -25,6 +25,7 @@
 - (BOOL)application:(UIApplication *)application
     didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   [GMSServices provideAPIKey:kMapsAPIKey];
+  [GMSServices setMetalRendererEnabled:YES];
 
   [GMTCServices setAccessTokenProvider:[[GRSCAuthTokenProvider alloc] init]
                             providerID:kProviderID];

--- a/objectivec_samples/Driver/DriverSampleApp/GRSDAppDelegate.m
+++ b/objectivec_samples/Driver/DriverSampleApp/GRSDAppDelegate.m
@@ -26,6 +26,7 @@
 - (BOOL)application:(UIApplication *)application
     didFinishLaunchingWithOptions:(NSDictionary<NSString *, __kindof NSObject *> *)launchOptions {
   [GMSServices provideAPIKey:kMapsAPIKey];
+  [GMSServices setMetalRendererEnabled:YES];
 
   // Register for notifications so that the SDK can post directions notifications when the app is
   // running in the background.

--- a/swift/consumer_swiftui/App/AppDelegate.swift
+++ b/swift/consumer_swiftui/App/AppDelegate.swift
@@ -22,6 +22,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
     GMSServices.provideAPIKey(APIConstants.mapsAPIKey)
+    GMSServices.setMetalRendererEnabled(true)
     GMTCServices.setAccessTokenProvider(AuthTokenProvider(), providerID: APIConstants.providerID)
     return true
   }

--- a/swift/driver_swiftui/App/AppDelegate.swift
+++ b/swift/driver_swiftui/App/AppDelegate.swift
@@ -21,6 +21,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
     GMSServices.provideAPIKey(APIConstants.mapsAPIKey)
+    GMSServices.setMetalRendererEnabled(true)
     return true
   }
 }


### PR DESCRIPTION
Metal is faster on simulators and enables the sample apps to run on M1 simulators.