### PR TITLE
build: update the min OS version for the Obj-C sample apps to 15.0

### DIFF
--- a/objectivec_samples/Consumer/Podfile
+++ b/objectivec_samples/Consumer/Podfile
@@ -1,6 +1,6 @@
 source 'https://github.com/CocoaPods/Specs.git'
 
 target 'ConsumerSampleApp' do
-  platform :ios, '14.0'
+  platform :ios, '15.0'
   pod 'GoogleRidesharingConsumer'
 end

--- a/objectivec_samples/Consumer/Podfile
+++ b/objectivec_samples/Consumer/Podfile
@@ -1,6 +1,6 @@
 source 'https://github.com/CocoaPods/Specs.git'
 
 target 'ConsumerSampleApp' do
-  platform :ios, '13.0'
+  platform :ios, '14.0'
   pod 'GoogleRidesharingConsumer'
 end

--- a/objectivec_samples/Driver/Podfile
+++ b/objectivec_samples/Driver/Podfile
@@ -1,6 +1,6 @@
 source 'https://github.com/CocoaPods/Specs.git'
 
 target 'DriverSampleApp' do
-  platform :ios, '13.0'
+  platform :ios, '14.0'
   pod 'GoogleRidesharingDriver'
 end

--- a/objectivec_samples/Driver/Podfile
+++ b/objectivec_samples/Driver/Podfile
@@ -1,6 +1,6 @@
 source 'https://github.com/CocoaPods/Specs.git'
 
 target 'DriverSampleApp' do
-  platform :ios, '14.0'
+  platform :ios, '15.0'
   pod 'GoogleRidesharingDriver'
 end


### PR DESCRIPTION
The Mobility Solutions SDKs dropped support for OS version 13.0 in the [v3.0.0 release](https://developers.google.com/maps/documentation/transportation-logistics/on-demand-rides-deliveries-solution/trip-order-progress/support/relnotes_consumer_sdk_ios#v300_may_2023).