### PR TITLE
fix: Remove Metal renderer API call

### DIFF
--- a/objectivec_samples/Consumer/App/GRSCAppDelegate.m
+++ b/objectivec_samples/Consumer/App/GRSCAppDelegate.m
@@ -25,7 +25,6 @@
 - (BOOL)application:(UIApplication *)application
     didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
   [GMSServices provideAPIKey:kMapsAPIKey];
-  [GMSServices setMetalRendererEnabled:YES];
 
   [GMTCServices setAccessTokenProvider:[[GRSCAuthTokenProvider alloc] init]
                             providerID:kProviderID];

--- a/objectivec_samples/Driver/DriverSampleApp/GRSDAppDelegate.m
+++ b/objectivec_samples/Driver/DriverSampleApp/GRSDAppDelegate.m
@@ -1,3 +1,4 @@
+
 /*
  * Copyright 2020 Google LLC. All rights reserved.
  *
@@ -26,7 +27,6 @@
 - (BOOL)application:(UIApplication *)application
     didFinishLaunchingWithOptions:(NSDictionary<NSString *, __kindof NSObject *> *)launchOptions {
   [GMSServices provideAPIKey:kMapsAPIKey];
-  [GMSServices setMetalRendererEnabled:YES];
 
   // Register for notifications so that the SDK can post directions notifications when the app is
   // running in the background.

--- a/objectivec_samples/Driver/DriverSampleApp/GRSDAppDelegate.m
+++ b/objectivec_samples/Driver/DriverSampleApp/GRSDAppDelegate.m
@@ -1,4 +1,3 @@
-
 /*
  * Copyright 2020 Google LLC. All rights reserved.
  *

--- a/swift/consumer_swiftui/App/AppDelegate.swift
+++ b/swift/consumer_swiftui/App/AppDelegate.swift
@@ -22,7 +22,6 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
     GMSServices.provideAPIKey(APIConstants.mapsAPIKey)
-    GMSServices.setMetalRendererEnabled(true)
     GMTCServices.setAccessTokenProvider(AuthTokenProvider(), providerID: APIConstants.providerID)
     return true
   }

--- a/swift/driver_swiftui/App/AppDelegate.swift
+++ b/swift/driver_swiftui/App/AppDelegate.swift
@@ -21,7 +21,6 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
     GMSServices.provideAPIKey(APIConstants.mapsAPIKey)
-    GMSServices.setMetalRendererEnabled(true)
     return true
   }
 }


### PR DESCRIPTION
The -setMetalRendererEnabled: API has been deprecated for some time, and it is now removed.